### PR TITLE
Fixed for Catalina

### DIFF
--- a/kext/onyx_the_black_cat.c
+++ b/kext/onyx_the_black_cat.c
@@ -73,9 +73,9 @@ onyx_the_black_cat_start (kmod_info_t * ki, void * d)
            "      The Black Cat v%s\n", VERSION);
     
     /* needs to be updated for every new major version supported */
-    if (version_major > MOJAVE)
+    if (version_major > CATALINA)
     {
-        LOG_ERROR("Only Mojave or lower supported!");
+        LOG_ERROR("Only Catalina or lower supported!");
         return KERN_FAILURE;
     }
     

--- a/kext/sysent.c
+++ b/kext/sysent.c
@@ -259,8 +259,7 @@ bruteforce_sysent(mach_vm_address_t *out_kernel_base)
     if (version_major >= CATALINA) {
         // search for the __DATA_CONST segment
         process_header(kernel_base, "__DATA_CONST", &segment_address, &segment_size);
-    }
-    else if (version_major >= SIERRA && version_major < CATALINA) {
+    } else if (version_major >= SIERRA) {
         // search for the __CONST segment
         process_header(kernel_base, "__CONST", &segment_address, &segment_size);
     } else {

--- a/kext/sysent.c
+++ b/kext/sysent.c
@@ -263,10 +263,10 @@ bruteforce_sysent(mach_vm_address_t *out_kernel_base)
         // search for the __CONST segment
         process_header(kernel_base, "__CONST", &segment_address, &segment_size);
     } else {
-		// search for the __DATA segment
-		process_header(kernel_base, "__DATA", &segment_address, &segment_size);
-	}
-	uint64_t segment_limit = segment_address + segment_size;
+        // search for the __DATA segment
+        process_header(kernel_base, "__DATA", &segment_address, &segment_size);
+    }
+    uint64_t segment_limit = segment_address + segment_size;
     // bruteforce search for sysent in __DATA segment
     while (segment_address <= segment_limit)
     {

--- a/kext/sysent.c
+++ b/kext/sysent.c
@@ -256,10 +256,14 @@ bruteforce_sysent(mach_vm_address_t *out_kernel_base)
     *out_kernel_base = kernel_base;
     uint64_t segment_address = 0;
     uint64_t segment_size = 0;
-	if (version_major >= SIERRA) {
-		// search for the __CONST segment
-		process_header(kernel_base, "__CONST", &segment_address, &segment_size);
-	} else {
+    if (version_major >= CATALINA) {
+        // search for the __DATA_CONST segment
+        process_header(kernel_base, "__DATA_CONST", &segment_address, &segment_size);
+    }
+    else if (version_major >= SIERRA && version_major < CATALINA) {
+        // search for the __CONST segment
+        process_header(kernel_base, "__CONST", &segment_address, &segment_size);
+    } else {
 		// search for the __DATA segment
 		process_header(kernel_base, "__DATA", &segment_address, &segment_size);
 	}


### PR DESCRIPTION
As of macOS 10.15 there seem to be some new Mach-O segments. What used to be in __CONST is now typically in __DATA_CONST in most Apple binaries.